### PR TITLE
History fix

### DIFF
--- a/ChatGPT/Views/ContentView.swift
+++ b/ChatGPT/Views/ContentView.swift
@@ -212,7 +212,7 @@ struct ContentView: View {
         for try await chunk in try viewModel.streamCallGPT(
           history: documentsViewModel.activeDocumentHistory
             .enumerated()
-            .filter({ $0.offset > documentsViewModel.activeDocumentHistory.count - 10 })
+            .filter({ $0.offset >= documentsViewModel.activeDocumentHistory.count - 10 })
             .map({ $0.element })
         ) {
           let messages = chunk as! [ChatOpenAILLM.Message]

--- a/ChatGPT/Views/ContentView.swift
+++ b/ChatGPT/Views/ContentView.swift
@@ -209,7 +209,12 @@ struct ContentView: View {
         )
         documentsViewModel.updateActiveHistory()
 
-        for try await chunk in try viewModel.streamCallGPT(history: documentsViewModel.activeDocumentHistory) {
+        for try await chunk in try viewModel.streamCallGPT(
+          history: documentsViewModel.activeDocumentHistory
+            .enumerated()
+            .filter({ $0.offset > documentsViewModel.activeDocumentHistory.count - 10 })
+            .map({ $0.element })
+        ) {
           let messages = chunk as! [ChatOpenAILLM.Message]
           for message in messages {
             let index = documentsViewModel.documentIndex(documentID: documentID)


### PR DESCRIPTION
Current solution:
Use only the last ten messages.

This is a quick solution to overcome max history error.
In the future, the solution has to count the number of tokens per message and filter out messages that exceed 8k count in the accumulative token sum.